### PR TITLE
Update src/DataCacheBehaviorQueryBuilderModifier.php

### DIFF
--- a/src/DataCacheBehaviorQueryBuilderModifier.php
+++ b/src/DataCacheBehaviorQueryBuilderModifier.php
@@ -107,8 +107,8 @@ public function getCacheKey()
         return \$this->cacheKey;
     }
     \$params      = array();
-    \$sql_hash    = hash('sha1', BasePeer::createSelectSql(\$this, \$params));
-    \$params_hash = hash('sha1', serialize(\$params));
+    \$sql_hash    = hash('md4', BasePeer::createSelectSql(\$this, \$params));
+    \$params_hash = hash('md4', serialize(\$params));
 
     \$this->cacheKey = \$sql_hash . '_' . \$params_hash;
 


### PR DESCRIPTION
since you don't need the cryptographic aspects of sha1, I suggest to use md4 instead which is nearly 2x faster in hashing.

see the benchmarks inside the comments section of...
http://php.net/manual/de/function.hash.php
