### PR TITLE
Update src/DataCacheBehaviorQueryBuilderModifier.php

### DIFF
--- a/src/DataCacheBehaviorQueryBuilderModifier.php
+++ b/src/DataCacheBehaviorQueryBuilderModifier.php
@@ -108,7 +108,7 @@ public function getCacheKey()
     }
     \$params      = array();
     \$sql_hash    = hash('sha1', BasePeer::createSelectSql(\$this, \$params));
-    \$params_hash = hash('sha1', serialize(\$params));
+    \$params_hash = hash('sha1', json_enocde(\$params));
 
     \$this->cacheKey = \$sql_hash . '_' . \$params_hash;
 


### PR DESCRIPTION
Use `json_encode` instead of `serialize` because it is 2x faster and requires less memory.

see http://stackoverflow.com/questions/804045/preferred-method-to-store-php-arrays-json-encode-vs-serialize
