### PR TITLE
Adding ability to manually manipulate cache data

### DIFF
--- a/src/DataCacheBehaviorObjectBuilderModifier.php
+++ b/src/DataCacheBehaviorObjectBuilderModifier.php
@@ -32,8 +32,6 @@ class DataCacheBehaviorObjectBuilderModifier
 
     public function postDelete($builder)
     {
-        $peerClassname = $builder->getStubPeerBuilder()->getClassname();
-
-        return "{$peerClassname}::purgeCache();";
+        return $this->postSave($builder);
     }
 }


### PR DESCRIPTION
Added ability to manually manipulate cache keys. Also added safeguard type checking for corrupted cache. Updated docs to match the propel 1.6.9 default generation where appropriate.
