### PR TITLE
set formatter when \PropelCollection is taken from cache

### DIFF
--- a/src/DataCacheBehaviorQueryBuilderModifier.php
+++ b/src/DataCacheBehaviorQueryBuilderModifier.php
@@ -197,6 +197,12 @@ public function getLifeTime()
 public function find(\$con = null)
 {
     if (\$this->isCacheEnable() && \$cache = {$peerClassname}::cacheFetch(\$this->getCacheKey())) {
+        if (\$cache instanceof \\PropelCollection)
+        {
+            \$formatter = \$this->getFormatter()->init(\$this);
+            \$cache->setFormatter(\$formatter);
+        }
+
         return \$cache;
     }
 


### PR DESCRIPTION
This small fix allows us to use `populateRelation` method on `\PropelObjectCollection` taken from cache. Before that there was error `Call to a member function getTableMap() on a non-object`
